### PR TITLE
Updated URLs in nse.py to parse the old NSE website

### DIFF
--- a/nse.py
+++ b/nse.py
@@ -54,26 +54,26 @@ class Nse(AbstractBaseExchange):
         self.opener = self.nse_opener()
         self.headers = self.nse_headers()
         # URL list
-        self.get_quote_url = 'https://www.nseindia.com/live_market/dynaContent/live_watch/get_quote/GetQuote.jsp?'
-        self.stocks_csv_url = 'http://www.nseindia.com/content/equities/EQUITY_L.csv'
-        self.top_gainer_url = 'http://www.nseindia.com/live_market/dynaContent/live_analysis/gainers/niftyGainers1.json'
-        self.top_loser_url = 'http://www.nseindia.com/live_market/dynaContent/live_analysis/losers/niftyLosers1.json'
+        self.get_quote_url = 'https://www1.nseindia.com/live_market/dynaContent/live_watch/get_quote/GetQuote.jsp?'
+        self.stocks_csv_url = 'http://www1.nseindia.com/content/equities/EQUITY_L.csv'
+        self.top_gainer_url = 'http://www1.nseindia.com/live_market/dynaContent/live_analysis/gainers/niftyGainers1.json'
+        self.top_loser_url = 'http://www1.nseindia.com/live_market/dynaContent/live_analysis/losers/niftyLosers1.json'
         self.top_fno_gainer_url\
-            = 'https://www.nseindia.com/live_market/dynaContent/live_analysis/gainers/fnoGainers1.json'
-        self.top_fno_loser_url = 'https://www.nseindia.com/live_market/dynaContent/live_analysis/losers/fnoLosers1.json'
-        self.advances_declines_url = 'http://www.nseindia.com/common/json/indicesAdvanceDeclines.json'
-        self.index_url="http://www.nseindia.com/homepage/Indices1.json"
-        self.bhavcopy_base_url = "https://www.nseindia.com/content/historical/EQUITIES/%s/%s/cm%s%s%sbhav.csv.zip"
+            = 'https://www1.nseindia.com/live_market/dynaContent/live_analysis/gainers/fnoGainers1.json'
+        self.top_fno_loser_url = 'https://www1.nseindia.com/live_market/dynaContent/live_analysis/losers/fnoLosers1.json'
+        self.advances_declines_url = 'http://www1.nseindia.com/common/json/indicesAdvanceDeclines.json'
+        self.index_url="http://www1.nseindia.com/homepage/Indices1.json"
+        self.bhavcopy_base_url = "https://www1.nseindia.com/content/historical/EQUITIES/%s/%s/cm%s%s%sbhav.csv.zip"
         self.bhavcopy_base_filename = "cm%s%s%sbhav.csv"
         self.active_equity_monthly_url =\
-            "https://www.nseindia.com/products/dynaContent/equities/equities/json/mostActiveMonthly.json"
-        self.year_high_url = "https://www.nseindia.com/products/dynaContent/equities/equities/json/online52NewHigh.json"
-        self.year_low_url = "https://www.nseindia.com/products/dynaContent/equities/equities/json/online52NewLow.json"
-        self.preopen_nifty_url = "https://www.nseindia.com/live_market/dynaContent/live_analysis/pre_open/nifty.json"
-        self.preopen_fno_url = "https://www.nseindia.com/live_market/dynaContent/live_analysis/pre_open/fo.json"
+            "https://www1.nseindia.com/products/dynaContent/equities/equities/json/mostActiveMonthly.json"
+        self.year_high_url = "https://www1.nseindia.com/products/dynaContent/equities/equities/json/online52NewHigh.json"
+        self.year_low_url = "https://www1.nseindia.com/products/dynaContent/equities/equities/json/online52NewLow.json"
+        self.preopen_nifty_url = "https://www1.nseindia.com/live_market/dynaContent/live_analysis/pre_open/nifty.json"
+        self.preopen_fno_url = "https://www1.nseindia.com/live_market/dynaContent/live_analysis/pre_open/fo.json"
         self.preopen_niftybank_url =\
-            "https://www.nseindia.com/live_market/dynaContent/live_analysis/pre_open/niftybank.json"
-        self.fno_lot_size_url = "https://www.nseindia.com/content/fo/fo_mktlots.csv"
+            "https://www1.nseindia.com/live_market/dynaContent/live_analysis/pre_open/niftybank.json"
+        self.fno_lot_size_url = "https://www1.nseindia.com/content/fo/fo_mktlots.csv"
 
     def get_fno_lot_sizes(self, cached=True, as_json=False):
         """
@@ -353,9 +353,7 @@ class Nse(AbstractBaseExchange):
         """
         return {'Accept': '*/*',
                 'Accept-Language': 'en-US,en;q=0.5',
-                'Host': 'nseindia.com',
-                'Referer': "https://www.nseindia.com/live_market\
-                /dynaContent/live_watch/get_quote/GetQuote.jsp?symbol=INFY&illiquid=0&smeFlag=0&itpFlag=0",
+                'Host': 'www1.nseindia.com',
                 'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:28.0) Gecko/20100101 Firefox/28.0',
                 'X-Requested-With': 'XMLHttpRequest'
                 }


### PR DESCRIPTION
Hey there,

The NSE website has been updated, however they're still offering the old website at www1.nseindia.com. I've updated the URLs in nse.py to reflect the same. 

I ran the nse_tests.py which has 1 failure - in the `test_6th_Dec_1994` test... The URL for downloading bhavs seems to throw a 403.