### PR TITLE
Add futures pricing quote

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -420,5 +420,79 @@ can do the following.
  .
  }
 
+Getting a Stock Futures Quote
+------------------------------
+
+You can get the current Futures quote for any stock, given its stock code and expiry date using the command below. Here, we fetch the current futures quote of State Bank of India. The NSE stock code for
+State Bank of India is **SBIN**.
+
+>>> fq = nse.get_futures_quote('sbin',expiry='29OCT2020')
+>>> from pprint import pprint
+>>> pprint(fq)
+{'annualisedVolatility': 54.99,
+ 'bestBuy': 2.84,
+ 'bestSell': 3.57,
+ 'buyPrice1': 197.95,
+ 'buyPrice2': 197.85,
+ 'buyPrice3': 197.0,
+ 'buyPrice4': 196.7,
+ 'buyPrice5': 196.35,
+ 'buyQuantity1': 3000.0,
+ 'buyQuantity2': 3000.0,
+ 'buyQuantity3': 3000.0,
+ 'buyQuantity4': 9000.0,
+ 'buyQuantity5': 3000.0,
+ 'change': '-5.20',
+ 'changeinOpenInterest': 87000.0,
+ 'clientWisePositionLimits': None,
+ 'closePrice': 198.05,
+ 'dailyVolatility': 2.88,
+ 'expiryDate': '29OCT2020',
+ 'highPrice': 205.2,
+ 'impliedVolatility': None,
+ 'instrumentType': 'FUTSTK',
+ 'lastPrice': 198.1,
+ 'lowPrice': 196.0,
+ 'ltp': 3.2,
+ 'marketLot': 3000.0,
+ 'marketWidePositionLimits': 746624593.0,
+ 'numberOfContractsTraded': 134.0,
+ 'openInterest': 591000.0,
+ 'openPrice': 205.05,
+ 'optionType': None,
+ 'pChange': '-2.56',
+ 'pchangeinOpenInterest': 17.26,
+ 'premiumTurnover': None,
+ 'prevClose': 203.3,
+ 'sellPrice1': 198.25,
+ 'sellPrice2': 198.3,
+ 'sellPrice3': 199.45,
+ 'sellPrice4': 199.5,
+ 'sellPrice5': 200.2,
+ 'sellQuantity1': 3000.0,
+ 'sellQuantity2': 3000.0,
+ 'sellQuantity3': 9000.0,
+ 'sellQuantity4': 45000.0,
+ 'sellQuantity5': 6000.0,
+ 'settlementPrice': 198.05,
+ 'strikePrice': None,
+ 'totalBuyQuantity': 78000.0,
+ 'totalSellQuantity': 129000.0,
+ 'turnoverinRsLakhs': 805.81,
+ 'underlying': 'SBIN',
+ 'underlyingValue': 196.8,
+ 'vwap': 200.45}
+>>>
+
+.. note::
+
+    The argument expiry is optional. You can also pass only Stock code as an argument.
+    In that case, it will fetch the result for the next upcoming expiry date.
+
+.. warning::
+
+    Always pass a valid expiry date. Otherwise the result will be a blank dict.
+    Also, take care of the proper format of expiry date.
+
  
  .. disqus::

--- a/nse.py
+++ b/nse.py
@@ -183,7 +183,7 @@ class Nse(AbstractBaseExchange):
         else:
             return None
 
-    def get_futures_quote(self, code, as_json=False):
+    def get_futures_quote(self, code, expiry='nodategiven', as_json=False):
         """
         gets the quote of futures derivative for a given stock code
         :param code:
@@ -192,7 +192,7 @@ class Nse(AbstractBaseExchange):
         """
         code = code.upper()
         if self.is_valid_code(code):
-            url = self.build_url_for_futures_quote(code)
+            url = self.build_url_for_futures_quote(code, expiry)
             req = Request(url, None, self.headers)
             # this can raise HTTPError and URLError, but we are not handling it
             # north bound APIs should use it for exception handling
@@ -420,14 +420,17 @@ class Nse(AbstractBaseExchange):
         else:
             raise Exception('code must be string')
 
-    def build_url_for_futures_quote(self, code):
+    def build_url_for_futures_quote(self, code, expiry):
         """
         builds a url which can be requested for futures dericative of given stock code
         :param code: string containing stock code.
         :return: a url object
         """
         if code is not None and type(code) is str:
-            encoded_args = urlencode([('underlying', code), ('instrument', 'FUTSTK')])
+            if expiry=='nodategiven':
+                encoded_args = urlencode([('underlying', code), ('instrument', 'FUTSTK')])
+            else:
+                encoded_args = urlencode([('underlying', code), ('instrument', 'FUTSTK'), ('expiry', expiry)])
             return self.get_derivative_quote_url + encoded_args
         else:
             raise Exception('code must be string')  

--- a/nse.py
+++ b/nse.py
@@ -144,6 +144,19 @@ class Nse(AbstractBaseExchange):
             else:
                 return False
 
+    def is_valid_fno_code(self, code):
+        """
+        Returns true if a stock has Futures and Options derivative
+        :param code: a string stock code
+        :return: Boolean
+        """
+        if code:
+            stock_codes = self.get_fno_lot_sizes()
+            if code.upper() in stock_codes.keys():
+                return True
+            else:
+                return False
+
     def get_quote(self, code, as_json=False):
         """
         gets the quote for a given stock code
@@ -183,7 +196,7 @@ class Nse(AbstractBaseExchange):
         else:
             return None
 
-    def get_futures_quote(self, code, expiry='nodategiven', as_json=False):
+    def get_futures_quote(self, code, expiry='NODATEGIVEN', as_json=False):
         """
         gets the quote of futures derivative for a given stock code
         :param code:
@@ -191,7 +204,8 @@ class Nse(AbstractBaseExchange):
         :raises: HTTPError, URLError
         """
         code = code.upper()
-        if self.is_valid_code(code):
+        expiry = expiry.upper()
+        if self.is_valid_fno_code(code):
             url = self.build_url_for_futures_quote(code, expiry)
             req = Request(url, None, self.headers)
             # this can raise HTTPError and URLError, but we are not handling it
@@ -427,7 +441,7 @@ class Nse(AbstractBaseExchange):
         :return: a url object
         """
         if code is not None and type(code) is str:
-            if expiry=='nodategiven':
+            if expiry=='NODATEGIVEN':
                 encoded_args = urlencode([('underlying', code), ('instrument', 'FUTSTK')])
             else:
                 encoded_args = urlencode([('underlying', code), ('instrument', 'FUTSTK'), ('expiry', expiry)])

--- a/tests/nse_tests.py
+++ b/tests/nse_tests.py
@@ -111,6 +111,18 @@ class TestCoreAPIs(unittest.TestCase):
         # the price changed in that very moment.
         self.assertDictEqual(resp, json.loads(json_resp))
 
+    def test_get_futures_quote(self):
+        code = 'sbin'
+        resp = self.nse.get_futures_quote(code)
+        self.assertIsInstance(resp, dict)
+        # test json response
+        json_resp = self.nse.get_quote(code, as_json=True)
+        self.assertIsInstance(json_resp, str)
+        # reconstruct the original dict from json
+        # this test may raise false alarms in case the
+        # the price changed in that very moment.
+        self.assertDictEqual(resp, json.loads(json_resp))
+
     def test_is_valid_code(self):
         code = 'infy'
         self.assertTrue(self.nse.is_valid_code(code))

--- a/tests/nse_tests.py
+++ b/tests/nse_tests.py
@@ -47,6 +47,18 @@ class TestCoreAPIs(unittest.TestCase):
                 for test_code in negative_codes:
                     url = self.nse.build_url_for_quote(test_code)
 
+    def test_build_url_for_futures_quote(self):
+        test_code = 'infy'
+        url = self.nse.build_url_for_futures_quote(test_code)
+        # 'test_code' should be present in the url
+        self.assertIsNotNone(re.search(test_code, url))
+
+    def test_negative_build_url_for_futures_quote(self):
+            negative_codes = [1, None]
+            with self.assertRaises(Exception):
+                for test_code in negative_codes:
+                    url = self.nse.build_url_for_futures_quote(test_code)
+
     def test_response_cleaner(self):
         test_dict = {
             'a': '10',
@@ -116,7 +128,7 @@ class TestCoreAPIs(unittest.TestCase):
         resp = self.nse.get_futures_quote(code)
         self.assertIsInstance(resp, dict)
         # test json response
-        json_resp = self.nse.get_quote(code, as_json=True)
+        json_resp = self.nse.get_futures_quote(code, as_json=True)
         self.assertIsInstance(json_resp, str)
         # reconstruct the original dict from json
         # this test may raise false alarms in case the
@@ -127,9 +139,17 @@ class TestCoreAPIs(unittest.TestCase):
         code = 'infy'
         self.assertTrue(self.nse.is_valid_code(code))
 
+    def test_is_valid_fno_code(self):
+        code = 'infy'
+        self.assertTrue(self.nse.is_valid_fno_code(code))
+
     def test_negative_is_valid_code(self):
         wrong_code = 'in'
         self.assertFalse(self.nse.is_valid_code(wrong_code))
+
+    def test_negative_is_valid_fno_code(self):
+        wrong_code = 'in'
+        self.assertFalse(self.nse.is_valid_fno_code(wrong_code))
 
     def test_get_top_gainers(self):
         res = self.nse.get_top_gainers()


### PR DESCRIPTION
## What
I have added the function `get_futures_quote`. It fetches the live futures pricing quote of a stock with its NSE code as input. It also takes expiry date as input which is optional. Incase expiry date is not given as input, it fetches the futures quote with the nearest expiry date.   

I have also added the test for the function in `/tests/nse_tests.py` and have properly tested its functioning and corner cases.   

I have updated the documentation too in `/docs/source/usage.rst` for this function.