### PR TITLE
Adds the field 'lastUpdatedTime' to nse response

### DIFF
--- a/nse.py
+++ b/nse.py
@@ -174,7 +174,9 @@ class Nse(AbstractBaseExchange):
                 # reliable. 
                 #buffer = js_adaptor(buffer)
                 #response = self.clean_server_response(ast.literal_eval(buffer)['data'][0])
+                lastUpdateTime = json.loads(buffer)['lastUpdateTime']
                 response = self.clean_server_response(json.loads(buffer)['data'][0])
+                response['lastUpdateTime'] = lastUpdateTime
             except SyntaxError as err:
                 raise Exception('ill formatted response')
             else:


### PR DESCRIPTION
Self-explanatory, I was thinking of adding a separate function to convert the string into a proper datetime() object, is it better to convert to a datetime() object?.

The cleaner way you be to pass the whole (buffer) to clean_server_respone. But I just wanted a quick fix. It isn't even harmful.